### PR TITLE
[Fix] pages action fails when npm build fails

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    continue-on-error: false
     steps:
       - uses: actions/checkout@v4
         with:
@@ -31,6 +32,7 @@ jobs:
         run: npm install
       - name: Build
         run: npm run build
+        continue-on-error: false
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
Recently a problem with the git theme submodule and the current logbook surfaces.
There was an error at the `npm run build` step in the pages action that was not "caught"
The steps in the pages.yml action continued and the action was "green"
This PR hopes to fix that but forcing the action to fail when the build step fails.

The fix is from [here](https://www.kenmuse.com/blog/how-to-handle-step-and-job-errors-in-github-actions/)