### PR TITLE
[Fix] force pages.yml action fail on npm build step fail

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    continue-on-error: false
     steps:
       - uses: actions/checkout@v4
         with:
@@ -31,6 +32,7 @@ jobs:
         run: npm install
       - name: Build
         run: npm run build
+        continue-on-error: false
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "build": "hexo generate",
+    "build": "hexo generate || exit 1",
     "clean": "hexo clean",
     "deploy": "hexo deploy",
     "server": "hexo server"


### PR DESCRIPTION
So `continue-on-error` did not work
Now trying an explicit `|| exit 1` in the package.json build step for the project