### PR TITLE
[Fix] npm build fails but action does not reflect

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -15,12 +15,12 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           # If your repository depends on submodule, please see: https://github.com/actions/checkout
           submodules: recursive
-      - name: Use Node.js 20
+      - name: Use Node.js 22
         uses: actions/setup-node@v4
         with:
           # Examples: 20, 18.19, >=16.20.2, lts/Iron, lts/Hydrogen, *, latest, current, node
           # Ref: https://github.com/actions/setup-node#supported-version-syntax
-          node-version: "20"
+          node-version: "22"
       - name: Cache NPM dependencies
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
For some strange reason I can build the site locally, but with GH pages.yml action the `hexo generate` fails but the job continues. I don't know how to fix this "false pipe" so I am just trying to get this to working 😢 